### PR TITLE
Fixing erroneously required argument attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Next
+- Fixed overridden initializer bug that always required an attributes hash
+  present in the arguments
 
 ## 0.0.7.pre
 - Alloving versions as low as 3.2 for active resource in order to work with the

--- a/lib/api_consumer.rb
+++ b/lib/api_consumer.rb
@@ -26,7 +26,7 @@ module ApiConsumer
 
   module Base
     module Initializer
-      def initialize(attributes, persisted = false)
+      def initialize(attributes = {}, persisted = false)
         if Attributes::Base.new(attributes).standardized?
           attributes = attributes.fetch('data')
         end


### PR DESCRIPTION
Required to fix thebeansgroup/editorial_consumer#22
